### PR TITLE
Login test 5

### DIFF
--- a/kbhff/api/delete_user.py
+++ b/kbhff/api/delete_user.py
@@ -26,4 +26,4 @@ def delete_user(user_data):
         click_button(driver, xpath="//form[@class='confirm_cancellation']/descendant::input[contains(@class, 'button')]") # "Farvel" button
         
         assert_current_page_is("login", driver, retryCount=10)
-        assert_text_on_page("Dine oplysninger blev slettet", driver)
+        assert_text_on_page("Dine oplysninger blev slettet", driver, retryCount=10)

--- a/kbhff/api/delete_user.py
+++ b/kbhff/api/delete_user.py
@@ -1,4 +1,6 @@
 from kbhff.api.navigation import *
+from kbhff.api.webpage_patterns import get_verification_token_on_first_login
+from kbhff.api.webpage_patterns import input_verification_token
 
 def delete_user(user_data):
     """Deletes the given user by logging in and following the deletion flow.
@@ -12,12 +14,16 @@ def delete_user(user_data):
 
     This method uses its own selenium driver, so doesn't disturb the flow of the enclosing test"""
     with webdriver.Firefox() as driver:
-        login(driver, user_data["email"], user_data["password"])
+        try_login(driver, user_data["email"], user_data["password"])
+        # if necessary, activate user before deletion
+        if driver.current_url == pages["bekraeft_konto"]: 
+            token = get_verification_token_on_first_login(user_data["email"])
+            input_verification_token(token, driver)
+            login(driver, user_data["email"], user_data["password"])
         click_button(driver, class_name="button.warning")
         click_button(driver, class_name="button.delete_me")
         fill_form_field(user_data["password"], driver, "input_password")
         click_button(driver, xpath="//form[@class='confirm_cancellation']/descendant::input[contains(@class, 'button')]") # "Farvel" button
         
-        wait_for_next_page(driver)
         assert_current_page_is("login", driver, retryCount=10)
         assert_text_on_page("Dine oplysninger blev slettet", driver)

--- a/kbhff/api/navigation.py
+++ b/kbhff/api/navigation.py
@@ -137,6 +137,7 @@ def fill_form_field(value, driver, form_id=None, class_name=None):
 
     It is compulsory to specify precisely one of form_id and class_name, otherwise the function will raise an InvalidArgumentsError"""
     entry_field = find_form_field(driver, form_id=form_id, class_name = class_name)
+    entry_field.clear()
     entry_field.send_keys(value)
 
 def get_form_field_value(driver, form_id=None, class_name=None):

--- a/kbhff/api/webpage_patterns.py
+++ b/kbhff/api/webpage_patterns.py
@@ -2,7 +2,7 @@ from kbhff.api.navigation import *
 from kbhff.api.email import *
 
 def get_verification_token_on_first_login(user_email, email_connection=None):
-    mail = get_latest_mail_to(user_email, email_connection=email_connection, expect_title="Aktiver din konto hos KBHFF", retryCount=5)
+    mail = get_latest_mail_to(user_email, email_connection=email_connection, expect_title="Aktiver din konto hos KBHFF", retryCount=25)
     return get_activation_code_from_email(mail.body)
 
 def input_verification_token(token, driver):

--- a/kbhff/api/webpage_patterns.py
+++ b/kbhff/api/webpage_patterns.py
@@ -24,4 +24,6 @@ def assert_username_prefilled(username, driver):
     assert_current_page_is("login", driver)
     assert get_form_field_value(driver, form_id="input_username") == username
 
-
+def assert_username_not_prefilled(username, driver):
+    assert_current_page_is("login", driver)
+    assert get_form_field_value(driver, form_id="input_username") != username

--- a/kbhff/test/login_test.py
+++ b/kbhff/test/login_test.py
@@ -90,3 +90,15 @@ def test_unverifiedUserWithPasswordFirstLogin(driver, gmail, unverified_user_via
     assert_username_prefilled(user["email"], driver)
     assert_text_on_page("Din konto er nu aktiveret og du kan logge ind", driver)
 
+#Test specification number 5
+def test_unverifiedUserWithPasswordFirstLoginIncorrectCode(driver, unverified_user_via_webform):
+    user = unverified_user_via_webform
+
+    navigate_to_page("login", driver)
+    try_login(driver, user["email"], user["password"])
+    assert_current_page_is("bekraeft_konto", driver)
+    wrong_token = "111aaaaa"
+    input_verification_token(wrong_token, driver)
+    assert_current_page_is("login", driver)
+    assert_username_not_prefilled("", driver)
+    assert_text_on_page("Beklager, det lykkedes ikke at aktivere", driver)


### PR DESCRIPTION
As this is the first test that exits without verifying the user it created, delete_user was modified to verify the user to delete if necessary to avoid errors at teardown.