### PR TITLE
Email connection integrity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 # install dependencies
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
-  - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
   - mkdir geckodriver chromedriver
   - tar -xzf geckodriver-v0.24.0-linux64.tar.gz -C geckodriver
   - unzip chromedriver_linux64.zip -d chromedriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - pip install -r requirements.txt
 # run tests
 script:
-  - pytest
+  - pytest --maxfail=1 -ra

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@
 There are two ways to use this package with a gmail account.
   1. Define two environment variables `MAIL_CREDENTIALS_EMAIL` containing your gmail address as string and `MAIL_CREDENTIALS_PASSWORD` containing the password to your account as string
   2. Add a `mail_credentials.py` file to `kbhff/api/` as in the first installation step above. This file should define a `dict` called `mail_credentials` with keys `"login"` and `"password"` mapping your gmail address and its password as strings. Make sure to (re)install after adding this file.
+
+## Further Notes
+
+It might be advisable to limit the concurrent jobs on TravisCI to e.g. one, as connecting to gmail is significantly slower and possibly more prone to errors if there are competing instances trying to connect.

--- a/kbhff/api/email.py
+++ b/kbhff/api/email.py
@@ -18,15 +18,15 @@ class GmailConnection:
             self.connection.quit()
         address = self.mail_credentials["login"]
         password = self.mail_credentials["password"]
-        self.connection = easyimap.connect ('imap.gmail.com', address, password)
+        self.connection = easyimap.connect('imap.gmail.com', address, password)
 
-    def listup(self, number_of_mails = 25, retries_left = 3):
+    def listup(self, number_of_mails = 25, retries_left = 100):
         try:
             return self.connection.listup(number_of_mails)
         except imaplib.IMAP4.abort:
-            print(" Reconnecting to Gmail... {} tries left.".format(retries_left))
             if retries_left < 1:
                 raise GmailConnectionError
+            time.sleep(1)
             self.connect()
             return self.listup(number_of_mails, retries_left-1)
 
@@ -44,13 +44,12 @@ def get_mail_credentials():
     return mail_credentials
 
 
-
 def get_latest_mail_to(to_address, email_connection = None, expect_title = None, retry_count = 10):
     """ Receive latest email sent to to_address.
 
     Optional parameters:
         expect_title --- if set, emails with titles that aren't an exact match will be ignored
-        retry --- retry this many times with a second's delay each
+        retry --- retry this many times with a 10 second of delay between each
         email_connection --- if an easyimap imapper with an existing connection is passed, this will be used to look up emails. Otherwise, a default connection as passed by get_gmail_connection is established and used.
     """
 
@@ -65,7 +64,7 @@ def get_latest_mail_to(to_address, email_connection = None, expect_title = None,
     for i in range(0,retry_count):
         if len(matches) > 0:
             break
-        time.sleep(1)
+        time.sleep(10)
         matches = list(filter(mail_match, email_connection.listup(25))) 
 
     if len(matches) > 0:

--- a/kbhff/api/email.py
+++ b/kbhff/api/email.py
@@ -24,6 +24,7 @@ class GmailConnection:
         try:
             return self.connection.listup(number_of_mails)
         except imaplib.IMAP4.abort:
+            print(" Reconnecting to Gmail... {} tries left.".format(retries_left))
             if retries_left < 1:
                 raise GmailConnectionError
             self.connect()

--- a/kbhff/api/email.py
+++ b/kbhff/api/email.py
@@ -2,6 +2,7 @@ import easyimap, email
 from kbhff.api.exceptions import *
 import time
 import imaplib
+import sys
 
 class GmailConnection:
     def __init__(self):
@@ -24,6 +25,7 @@ class GmailConnection:
         try:
             return self.connection.listup(number_of_mails)
         except imaplib.IMAP4.abort:
+            sys.stderr.write("Gmail connection had to reconnect after IMAP4.abort")
             if retries_left < 1:
                 raise GmailConnectionError
             time.sleep(1)

--- a/kbhff/api/email.py
+++ b/kbhff/api/email.py
@@ -1,6 +1,7 @@
 import easyimap, email
 from kbhff.api.exceptions import *
 import time
+import imaplib
 
 class GmailConnection:
     def __init__(self):

--- a/kbhff/api/exceptions.py
+++ b/kbhff/api/exceptions.py
@@ -35,3 +35,7 @@ class UnexpectedPageError(KbhffApiError):
 class TextNotFoundOnPageError(KbhffApiError):
     """ Raised when expected text is not shown on current page. """
     pass
+
+class GmailConnectionError(KbhffApiError):
+    """Raised when the connection to gmail fails. """
+    pass

--- a/kbhff/test/api_test.py
+++ b/kbhff/test/api_test.py
@@ -122,5 +122,5 @@ def test_haveMailCredentials():
 
 def test_canLogIntoGmail():
     # raises imaplib.error if e.g. authentication fails
-    gmail = get_gmail_connection()
-    gmail.quit()
+    gmail = GmailConnection()
+    del gmail

--- a/kbhff/test/api_test.py
+++ b/kbhff/test/api_test.py
@@ -124,3 +124,7 @@ def test_canLogIntoGmail():
     # raises imaplib.error if e.g. authentication fails
     gmail = GmailConnection()
     del gmail
+
+def test_GmailConnectionCanHandleFastQueries(gmail):
+    for _ in range(10):
+        last_mails = gmail.listup()

--- a/kbhff/test/fixtures.py
+++ b/kbhff/test/fixtures.py
@@ -9,9 +9,8 @@ from pyvirtualdisplay import Display
 
 @pytest.fixture(scope="module")
 def gmail():
-    gmail = get_gmail_connection()
+    gmail = GmailConnection()
     yield gmail
-    gmail.quit()
 
 @pytest.fixture(scope="function", params = [webdriver.Firefox, webdriver.Chrome] )
 def driver(request):

--- a/kbhff/test/fixtures.py
+++ b/kbhff/test/fixtures.py
@@ -7,7 +7,7 @@ from kbhff.api.delete_user import *
 
 from pyvirtualdisplay import Display
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def gmail():
     gmail = GmailConnection()
     yield gmail


### PR DESCRIPTION
instead of baremetal `easyimap.connection`, we now have a wrapped-up version in that handles retries if the connection breaks down, which I believe is why the TravisCI Server kept having problems. 